### PR TITLE
Update Encoder for mBART50

### DIFF
--- a/torchseq/datasets/json_dataset.py
+++ b/torchseq/datasets/json_dataset.py
@@ -94,6 +94,9 @@ class JsonDataset(Dataset):
         tgt_lang = obj.get("tgt_lang", "en_XX")
 
         if include_lang_codes:
+            assert src_lang in FAIRSEQ_LANGUAGE_CODES, f"Value in src_lang:\"{src_lang}\" attribute not recognised. Check FAIRSEQ_LANGUAGE_CODES in tokenizer.py"
+            assert tgt_lang in FAIRSEQ_LANGUAGE_CODES, f"Value in tgt_lang:\"{tgt_lang}\" attribute not recognised. Check FAIRSEQ_LANGUAGE_CODES in tokenizer.py"
+
             src_lang_token = FAIRSEQ_LANGUAGE_CODES[src_lang]
             tgt_lang_token = FAIRSEQ_LANGUAGE_CODES[tgt_lang]
 

--- a/torchseq/datasets/json_dataset.py
+++ b/torchseq/datasets/json_dataset.py
@@ -82,14 +82,15 @@ class JsonDataset(Dataset):
             self.output_tokenizer,
             tok_window=self.config.prepro.tok_window,
             include_lang_codes=self.config.prepro.data.get("include_lang_codes", False),
+            drop_target_lang_codes=self.config.prepro.data.get("drop_target_lang_codes", False),
             mask_prob=self.config.prepro.data.get("token_mask_prob", 0),
         )
 
     @staticmethod
     def to_tensor(
-        obj, fields, input_tokenizer, output_tokenizer, tok_window=64, include_lang_codes=False, mask_prob=0.0
+        obj, fields, input_tokenizer, output_tokenizer, tok_window=64, include_lang_codes=False, drop_target_lang_codes=False, mask_prob=0.0
     ):
-
+        
         src_lang = obj.get("src_lang", "en_XX")
         tgt_lang = obj.get("tgt_lang", "en_XX")
 
@@ -110,7 +111,7 @@ class JsonDataset(Dataset):
             # HACK: this should be in a config somewhere...
             if include_lang_codes and f["to"] == "source":
                 lang_tok = [src_lang_token]
-            elif include_lang_codes and f["to"] == "target":
+            elif include_lang_codes and not drop_target_lang_codes and f["to"] == "target": # In semparse we don't need this on the output side
                 lang_tok = [tgt_lang_token]
             else:
                 lang_tok = []

--- a/torchseq/datasets/json_dataset.py
+++ b/torchseq/datasets/json_dataset.py
@@ -88,15 +88,26 @@ class JsonDataset(Dataset):
 
     @staticmethod
     def to_tensor(
-        obj, fields, input_tokenizer, output_tokenizer, tok_window=64, include_lang_codes=False, drop_target_lang_codes=False, mask_prob=0.0
+        obj,
+        fields,
+        input_tokenizer,
+        output_tokenizer,
+        tok_window=64,
+        include_lang_codes=False,
+        drop_target_lang_codes=False,
+        mask_prob=0.0,
     ):
-        
+
         src_lang = obj.get("src_lang", "en_XX")
         tgt_lang = obj.get("tgt_lang", "en_XX")
 
         if include_lang_codes:
-            assert src_lang in FAIRSEQ_LANGUAGE_CODES, f"Value in src_lang:\"{src_lang}\" attribute not recognised. Check FAIRSEQ_LANGUAGE_CODES in tokenizer.py"
-            assert tgt_lang in FAIRSEQ_LANGUAGE_CODES, f"Value in tgt_lang:\"{tgt_lang}\" attribute not recognised. Check FAIRSEQ_LANGUAGE_CODES in tokenizer.py"
+            assert (
+                src_lang in FAIRSEQ_LANGUAGE_CODES
+            ), f'Value in src_lang:"{src_lang}" attribute not recognised. Check FAIRSEQ_LANGUAGE_CODES in tokenizer.py'
+            assert (
+                tgt_lang in FAIRSEQ_LANGUAGE_CODES
+            ), f'Value in tgt_lang:"{tgt_lang}" attribute not recognised. Check FAIRSEQ_LANGUAGE_CODES in tokenizer.py'
 
             src_lang_token = FAIRSEQ_LANGUAGE_CODES[src_lang]
             tgt_lang_token = FAIRSEQ_LANGUAGE_CODES[tgt_lang]
@@ -111,7 +122,9 @@ class JsonDataset(Dataset):
             # HACK: this should be in a config somewhere...
             if include_lang_codes and f["to"] == "source":
                 lang_tok = [src_lang_token]
-            elif include_lang_codes and not drop_target_lang_codes and f["to"] == "target": # In semparse we don't need this on the output side
+            elif (
+                include_lang_codes and not drop_target_lang_codes and f["to"] == "target"
+            ):  # In semparse we don't need this on the output side
                 lang_tok = [tgt_lang_token]
             else:
                 lang_tok = []

--- a/torchseq/models/bottleneck_autoencoder.py
+++ b/torchseq/models/bottleneck_autoencoder.py
@@ -345,7 +345,7 @@ class BottleneckAutoencoderModel(nn.Module):
                                 encoding_pooled[:, :, self.sep_splice_ix :]
                                 - template_encoding_pooled[:, :, self.sep_splice_ix :]
                             )
-                            similarity_loss = (diff1**2).mean(dim=-1).mean(dim=-1)
+                            similarity_loss = (diff1 ** 2).mean(dim=-1).mean(dim=-1)
 
                             diff2 = (
                                 encoding_pooled[:, :, : self.sep_splice_ix]
@@ -357,7 +357,7 @@ class BottleneckAutoencoderModel(nn.Module):
                                 encoding_pooled[:, :, : self.sep_splice_ix]
                                 - template_encoding_pooled[:, :, : self.sep_splice_ix]
                             )
-                            similarity_loss = (diff1**2).mean(dim=-1).mean(dim=-1)
+                            similarity_loss = (diff1 ** 2).mean(dim=-1).mean(dim=-1)
 
                             diff2 = (
                                 encoding_pooled[:, :, self.sep_splice_ix :]

--- a/torchseq/models/bottleneck_autoencoder.py
+++ b/torchseq/models/bottleneck_autoencoder.py
@@ -38,7 +38,7 @@ class BottleneckAutoencoderModel(nn.Module):
         self.seq_encoder = SequenceEncoder(
             config,
             self.input_tokenizer,
-            freeze_embeddings=config.encoder.get("freeze_embeddings", config.get("freeze_embeddings", False))
+            freeze_embeddings=config.encoder.get("freeze_embeddings", config.get("freeze_embeddings", False)),
         )
 
         if config.bottleneck.get("modular", False):

--- a/torchseq/models/bottleneck_autoencoder.py
+++ b/torchseq/models/bottleneck_autoencoder.py
@@ -38,7 +38,7 @@ class BottleneckAutoencoderModel(nn.Module):
         self.seq_encoder = SequenceEncoder(
             config,
             self.input_tokenizer,
-            freeze_embeddings=config.encoder.get("freeze_embeddings", config.get("freeze_embeddings", False)),
+            freeze_embeddings=config.encoder.get("freeze_embeddings", config.get("freeze_embeddings", False))
         )
 
         if config.bottleneck.get("modular", False):

--- a/torchseq/models/bottleneck_autoencoder.py
+++ b/torchseq/models/bottleneck_autoencoder.py
@@ -345,7 +345,7 @@ class BottleneckAutoencoderModel(nn.Module):
                                 encoding_pooled[:, :, self.sep_splice_ix :]
                                 - template_encoding_pooled[:, :, self.sep_splice_ix :]
                             )
-                            similarity_loss = (diff1 ** 2).mean(dim=-1).mean(dim=-1)
+                            similarity_loss = (diff1**2).mean(dim=-1).mean(dim=-1)
 
                             diff2 = (
                                 encoding_pooled[:, :, : self.sep_splice_ix]
@@ -357,7 +357,7 @@ class BottleneckAutoencoderModel(nn.Module):
                                 encoding_pooled[:, :, : self.sep_splice_ix]
                                 - template_encoding_pooled[:, :, : self.sep_splice_ix]
                             )
-                            similarity_loss = (diff1 ** 2).mean(dim=-1).mean(dim=-1)
+                            similarity_loss = (diff1**2).mean(dim=-1).mean(dim=-1)
 
                             diff2 = (
                                 encoding_pooled[:, :, self.sep_splice_ix :]

--- a/torchseq/models/encoder.py
+++ b/torchseq/models/encoder.py
@@ -18,7 +18,6 @@ class SequenceEncoder(nn.Module):
         super().__init__()
         self.config = config
         self.tokenizer = tokenizer
-        self.logger = logging.getLogger(__file__)
 
         # Embedding layers
         if embeddings is not None:
@@ -151,7 +150,7 @@ class SequenceEncoder(nn.Module):
             bert_padding_mask = (~padding_mask).long()
 
             bert_typeids = {}
-            
+
             self.bert_encoding = self.bert_encoder(
                 input_ids=input_seq.to(input_seq.device), attention_mask=bert_padding_mask, **bert_typeids
             )[0]

--- a/torchseq/models/encoder.py
+++ b/torchseq/models/encoder.py
@@ -151,9 +151,9 @@ class SequenceEncoder(nn.Module):
             bert_padding_mask = (~padding_mask).long()
 
             bert_typeids = {}
-
+            
             self.bert_encoding = self.bert_encoder(
-                input_ids=input_seq, attention_mask=bert_padding_mask, **bert_typeids
+                input_ids=input_seq.to(input_seq.device), attention_mask=bert_padding_mask, **bert_typeids
             )[0]
 
             if self.config.encdec.num_encoder_layers > 0:

--- a/torchseq/utils/tokenizer.py
+++ b/torchseq/utils/tokenizer.py
@@ -90,7 +90,7 @@ FAIRSEQ_LANGUAGE_CODES = {  # NOTE(SS): resize embeddings will break this
     "ur_PK": 250049,
     "xh_ZA": 250050,
     "gl_ES": 250051,
-    "sl_SI": 250052
+    "sl_SI": 250052,
 }
 
 
@@ -184,7 +184,6 @@ class Tokenizer:
             self.bos_id = self.engine.token_to_id("[CLS]")
             self.eos_id = self.engine.token_to_id("[SEP]")
 
-
         # Vocab size from PretrainedFastTokenize is __len__ attr
         if "mbart-" in model_slug:
             self.vocab_size = len(self.engine)
@@ -221,7 +220,7 @@ class Tokenizer:
 
             token_ids = output["input_ids"]
             offsets = output["offset_mapping"]
-            token_texts = output.tokens() # tokens() is a method in PretrainedFastTokenizer
+            token_texts = output.tokens()  # tokens() is a method in PretrainedFastTokenizer
         else:
             output = self.engine.encode(text)
 


### PR DESCRIPTION
* JSON Dataset now allows only source side language token
* Encoder now loads `MBartModel` when required because `MBartModel != BartModel`
* Standardise key_padding_mask in inputs to be similar for Bart variants and Bert
* mBART50 tokenisation now matches other implementations and uses Fast variant